### PR TITLE
need to include #include <boost/type_traits/is_reference.hpp> 

### DIFF
--- a/src/nc/common/CheckedCast.h
+++ b/src/nc/common/CheckedCast.h
@@ -28,6 +28,7 @@
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/type_traits/is_polymorphic.hpp>
 #include <boost/type_traits/is_pointer.hpp>
+#include <boost/type_traits/is_reference.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/mpl/and.hpp>
 


### PR DESCRIPTION
or else it will fail to compile with boost 1.60

compilation errors:

smartdec-git/src/nc/common/CheckedCast.h: In function ‘typename boost::enable_ifboost::is_polymorphic<From, To>::type nc::checked_cast(From&)’:
smartdec-git/src/smartdec-git/src/nc/common/CheckedCast.h:87:23: error: ‘is_reference’ is not a member of ‘boost’
         static_assert(boost::is_reference<To>::value, "Target type must be a reference");
                       ^~~~~
smartdec-git/src/smartdec-git/src/nc/common/CheckedCast.h:87:23: note: suggested alternative:
In file included from /usr/include/c++/6.1.1/bits/move.h:57:0,
                 from /usr/include/c++/6.1.1/bits/stl_pair.h:59,
                 from /usr/include/c++/6.1.1/bits/stl_algobase.h:64,
                 from /usr/include/c++/6.1.1/bits/char_traits.h:39,
                 from /usr/include/c++/6.1.1/string:40,
                 from smartdec-git/src/smartdec-git/src/nc/core/arch/Operands.h:26,
                 from smartdec-git/src/smartdec-git/src/nc/core/arch/Operands.cpp:22:
/usr/include/c++/6.1.1/type_traits:570:12: note:   ‘std::is_reference’
     struct is_reference
            ^~~~~~~~~~~~
In file included from smartdec-git/src/smartdec-git/src/nc/core/arch/Operands.h:33:0,
                 from /smartdec-git/src/smartdec-git/src/nc/core/arch/Operands.cpp:22:
smartdec-git/src/smartdec-git/src/nc/common/CheckedCast.h:87:45: error: expected primary-expression before ‘>’ token
         static_assert(boost::is_reference<To>::value, "Target type must be a reference");
                                             ^
smartdec-git/src/smartdec-git/src/nc/common/CheckedCast.h:87:46: error: ‘::value’ has not been declared
         static_assert(boost::is_reference<To>::value, "Target type must be a reference");
                                              ^~
This patch fixes this issue, please merge it at your earliest covience
